### PR TITLE
Add "Open and Archive" action to Raindrop.io extension

### DIFF
--- a/extensions/raindrop-io/GLAUDE.md
+++ b/extensions/raindrop-io/GLAUDE.md
@@ -1,0 +1,110 @@
+# Raindrop.io Extension Enhancement Project
+
+## プロジェクト概要
+RaycastのRaindrop.io拡張機能をフォークして、「Latest Bookmarks」に新しいアクション機能を追加する。
+
+## 開発要件
+
+### 1. 基本機能追加
+- **対象**: `Latest Bookmarks` コマンド
+- **新機能**: 「Open and Archive」アクション
+- **ショートカット**: `cmd+o`
+- **動作**: 
+  1. 選択されたブックマークをブラウザで開く
+  2. 同時にそのブックマークをarchiveコレクションに移動する
+
+### 2. アクション詳細仕様
+- **表示名**: "Open and Archive"
+- **アイコン**: Archive (Lucide React)
+- **配置位置**: Deleteアクションの上
+- **優先度**: リンクを開くことを優先（コレクション移動は失敗してもリンクは開く）
+
+### 3. エラーハンドリング
+- **リンクを開く処理**: 最優先で実行
+- **コレクション移動失敗時**: Raycastトースト通知でエラー表示
+- **成功時**: 特別な通知なし、Latest Bookmarksを自動リロード
+
+### 4. Archive コレクション
+- **前提**: archiveコレクションは既存（コレクションIDは不明）
+- **ID取得方法**: 名前からコレクションIDを動的に検索・取得
+
+### 5. 開発ツール
+- **コレクション確認スクリプト**: `npm run show-collections` で全コレクション一覧とIDを表示
+- **用途**: 開発・デバッグ用
+
+## 技術要件
+
+### API仕様
+- **Raindrop.io API**: 既存の認証方式（Bearer Token）を継続使用
+- **必要なエンドポイント**:
+  - GET `/collections` - コレクション一覧取得
+  - PUT `/raindrop/{id}` - ブックマークのコレクション変更
+
+### 実装箇所
+- **ベースコード**: `https://github.com/raycast/extensions/tree/main/extensions/raindrop-io`
+- **主な変更ファイル**: Latest Bookmarks関連のコンポーネント
+- **新規追加**: package.jsonにスクリプト追加
+
+### Error Handling パターン
+```typescript
+try {
+  // 1. リンクを開く（最優先）
+  await openInBrowser(bookmark.link);
+  
+  // 2. archiveコレクションIDを取得
+  const collections = await getCollections();
+  const archiveCollection = collections.find(c => c.title.toLowerCase() === 'archive');
+  
+  if (!archiveCollection) {
+    throw new Error('Archive collection not found');
+  }
+  
+  // 3. ブックマークを移動
+  await moveToCollection(bookmark.id, archiveCollection._id);
+  
+  // 4. リストを更新
+  await revalidate();
+  
+} catch (error) {
+  // コレクション移動の失敗のみトースト表示
+  if (error.message.includes('collection') || error.message.includes('move')) {
+    showToast({
+      style: Toast.Style.Failure,
+      title: "Archive移動に失敗しました",
+      message: error.message
+    });
+  }
+}
+```
+
+### NPM Script 追加
+```json
+{
+  "scripts": {
+    "show-collections": "node scripts/show-collections.js"
+  }
+}
+```
+
+## 実装チェックリスト
+- [ ] 既存コードの分析と理解
+- [ ] Archive アクションの実装
+- [ ] コレクションID動的取得機能
+- [ ] エラーハンドリング実装
+- [ ] トースト通知実装
+- [ ] リスト自動リロード機能
+- [ ] コレクション確認スクリプト作成
+- [ ] テスト実行
+- [ ] 動作確認
+
+## 注意事項
+- リンクを開く処理は他の処理に関係なく必ず実行する
+- 既存の機能に影響を与えないよう注意
+- Raindrop.io APIのレート制限に注意
+- 既存のコードスタイルに合わせる
+
+## 期待される成果物
+1. 機能拡張されたRaindrop.io拡張機能
+2. コレクション確認用スクリプト
+3. 適切なエラーハンドリングとユーザーフィードバック
+4. 既存機能の非破壊的拡張

--- a/extensions/raindrop-io/package.json
+++ b/extensions/raindrop-io/package.json
@@ -233,6 +233,7 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
-    "publish": "npx -y @raycast/api@latest publish"
+    "publish": "npx -y @raycast/api@latest publish",
+    "show-collections": "node scripts/show-collections.js"
   }
 }

--- a/extensions/raindrop-io/scripts/show-collections.js
+++ b/extensions/raindrop-io/scripts/show-collections.js
@@ -1,0 +1,57 @@
+async function showCollections() {
+  const fetch = (await import('node-fetch')).default;
+  try {
+    // package.jsonからtoken情報を読み取る
+    const token = process.env.RAINDROP_TOKEN;
+    
+    if (!token) {
+      console.error('Error: RAINDROP_TOKEN environment variable is not set');
+      console.log('Usage: RAINDROP_TOKEN=your_token npm run show-collections');
+      process.exit(1);
+    }
+
+    const response = await fetch('https://api.raindrop.io/rest/v1/collections', {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`API responded with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    
+    console.log('\n=== Raindrop.io Collections ===\n');
+    
+    if (data.items && data.items.length > 0) {
+      data.items.forEach(collection => {
+        console.log(`ID: ${collection._id}`);
+        console.log(`Title: ${collection.title}`);
+        console.log(`Count: ${collection.count || 0}`);
+        if (collection.parent && collection.parent.$id > 0) {
+          console.log(`Parent ID: ${collection.parent.$id}`);
+        }
+        console.log('---');
+      });
+      
+      // Archive collectionを探して強調表示
+      const archiveCollection = data.items.find(c => c.title.toLowerCase() === 'archive');
+      if (archiveCollection) {
+        console.log('\n📦 Archive Collection Found:');
+        console.log(`   ID: ${archiveCollection._id}`);
+        console.log(`   Title: ${archiveCollection.title}`);
+      } else {
+        console.log('\n⚠️  No "archive" collection found!');
+      }
+    } else {
+      console.log('No collections found.');
+    }
+    
+  } catch (error) {
+    console.error('Error fetching collections:', error.message);
+    process.exit(1);
+  }
+}
+
+showCollections();

--- a/extensions/raindrop-io/src/components/BookmarkItem.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkItem.tsx
@@ -9,11 +9,13 @@ import {
   showToast,
   confirmAlert,
   Alert,
+  open,
 } from "@raycast/api";
 import { Bookmark } from "../types";
 import { getFavicon } from "@raycast/utils";
 import fetch from "node-fetch";
 import { BookmarkForm } from "./BookmarkForm";
+import { useCollections } from "../hooks/useCollections";
 
 function ActionEditBookmark(props: { bookmark: Bookmark; revalidate: () => void }) {
   const { bookmark, revalidate } = props;

--- a/extensions/raindrop-io/src/components/BookmarkItem.tsx
+++ b/extensions/raindrop-io/src/components/BookmarkItem.tsx
@@ -276,6 +276,12 @@ export default function BookmarkItem(props: { bookmark: Bookmark; revalidate: ()
           />
           <ActionEditBookmark bookmark={bookmark} revalidate={revalidate} />
           <Action
+            onAction={handleOpenAndArchive}
+            title="Open and Archive"
+            shortcut={{ modifiers: ["cmd"], key: "o" }}
+            icon={Icon.ArrowDown}
+          />
+          <Action
             onAction={handleDelete}
             title="Delete Bookmark"
             style={Action.Style.Destructive}


### PR DESCRIPTION
  ## Summary
  - Adds a new "Open and Archive" action to the Latest Bookmarks command that opens bookmarks and automatically moves them to the archive collection
  - Implements a developer utility script to inspect Raindrop.io collections for debugging purposes

  ## Motivation
  This feature addresses a common workflow pattern where users want to open a bookmark to read it and then archive it to keep their main collection organized. Currently, this
  requires two separate actions - opening the link and then manually moving it to the archive. This enhancement streamlines the process into a single keyboard shortcut.

  ## Changes

  ### New Features
  1. **Open and Archive Action** (`cmd+o`)
     - Opens the selected bookmark in the default browser
     - Automatically moves the bookmark to the "archive" collection
     - Prioritizes opening the link - if archiving fails, the link still opens successfully
     - Shows error toast notification only if the archive operation fails

  2. **Collection Inspector Script**
     - Added `npm run show-collections` command for developers
     - Displays all Raindrop.io collections with their IDs
     - Highlights the archive collection if found
     - Requires `RAINDROP_TOKEN` environment variable

  ### Technical Implementation
  - **Dynamic Collection Lookup**: The archive collection ID is fetched dynamically by name rather than being hardcoded
  - **Error Handling**: Implements graceful degradation where link opening is guaranteed even if archiving fails
  - **Integration**: Uses existing `useCollections` hook to access collection data
  - **UI Placement**: Action is positioned between "Edit Bookmark" and "Delete Bookmark" for logical workflow

  ### Files Modified
  - `src/components/BookmarkItem.tsx`: Added `handleOpenAndArchive` function and new action
  - `package.json`: Added `show-collections` script
  - `scripts/show-collections.js`: New utility script for collection inspection
  - `GLAUDE.md`: Project specification documentation (in Japanese)

  ## Testing
  To test the feature:
  1. Ensure you have an "archive" collection in your Raindrop.io account
  2. Select any bookmark in Latest Bookmarks
  3. Press `cmd+o` to trigger the Open and Archive action
  4. Verify the bookmark opens in your browser and moves to the archive collection

  To use the collection inspector:
  ```bash
  RAINDROP_TOKEN=your_token npm run show-collections

  Notes for Reviewers

  - The feature is designed to be non-destructive - existing functionality remains unchanged
  - The archive collection must exist and be named "archive" (case-insensitive)
  - Error messages are displayed in Japanese as per the project specification
  - The icon used is Icon.ArrowDown which represents the archiving action